### PR TITLE
Uppercase first letter to conform to command sails generate api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -294,7 +294,7 @@ AutoSequelize.prototype.write = function(attributes, callback) {
   async.each(tables, createFile, callback)
 
   function createFile(table, _callback){
-    fs.writeFile(path.resolve(path.join(self.options.directory, table + '.js')), attributes[table], _callback);
+    fs.writeFile(path.resolve(path.join(self.options.directory, table.charAt(0).toUpperCase() + '.js')), attributes[table], _callback);
   }
 }
 


### PR DESCRIPTION
There is need for uppercase of first letter to conform to command sails generate api.
